### PR TITLE
fix: data race on worker

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -62,7 +62,7 @@ func (w *Worker) processInfinity(ctx context.Context) {
 		return
 	}
 
-	parallel := parallel.NewParallel(ctx, w.parallelism)
+	parallel := parallel.NewParallel(ctx, atomic.LoadInt32(&w.parallelism))
 	defer parallel.Close()
 	w.mu.Lock()
 	w.parallel = parallel
@@ -90,7 +90,7 @@ func (w *Worker) processLimited(ctx context.Context, limit int) {
 		return
 	}
 
-	parallel := parallel.NewParallel(ctx, w.parallelism)
+	parallel := parallel.NewParallel(ctx, atomic.LoadInt32(&w.parallelism))
 	defer parallel.Close()
 	w.mu.Lock()
 	w.parallel = parallel


### PR DESCRIPTION
```
WARNING: DATA RACE
Write at 0x00c0003a0054 by goroutine 30:
  sync/atomic.StoreInt32()
      /Users/orisano/sdk/go1.15/src/runtime/race_amd64.s:229 +0xb
  github.com/isucon/isucandar/worker.(*Worker).SetParallelism()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/worker/worker.go:135 +0x8f
  github.com/isucon/isucandar/worker.(*Worker).AddParallelism()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/worker/worker.go:142 +0x58
  github.com/isucon/isucon10-final/benchmarker/scenario.(*Scenario).loadSignup.func2()
      /Users/orisano/works/isucon10-final/benchmarker/scenario/load.go:298 +0x8d

Previous read at 0x00c0003a0054 by goroutine 21:
  github.com/isucon/isucandar/worker.(*Worker).processInfinity()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/worker/worker.go:65 +0x84
  github.com/isucon/isucandar/worker.(*Worker).Process()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/worker/worker.go:54 +0x6f
  github.com/isucon/isucon10-final/benchmarker/scenario.(*Scenario).loadSignup()
      /Users/orisano/works/isucon10-final/benchmarker/scenario/load.go:308 +0x3c4
  github.com/isucon/isucon10-final/benchmarker/scenario.(*Scenario).Load()
      /Users/orisano/works/isucon10-final/benchmarker/scenario/load.go:49 +0x215
  github.com/isucon/isucandar.LoadScenario.Load-fm()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/benchmark_scenario.go:17 +0x68
  github.com/isucon/isucandar.(*Benchmark).Start.func3.1.1()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/benchmark.go:124 +0x5b
  github.com/isucon/isucandar.panicWrapper()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/benchmark.go:214 +0x72
  github.com/isucon/isucandar.(*Benchmark).Start.func3.1()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/benchmark.go:124 +0xbc
  github.com/isucon/isucandar/parallel.(*Parallel).Do.func1()
      /Users/orisano/go/pkg/mod/github.com/isucon/isucandar@v0.0.0-20200926185116-7df52f5ea47a/parallel/parallel.go:68 +0xa7
```
が発生したので修正